### PR TITLE
Add option for libdgm_compat, add option for gdbm-tool-debug

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.tools import get_env
 import os
-import tempfile
 
 
 class GdbmConan(ConanFile):
     name = "gdbm"
     version = "1.18.1"
-    description = "gdbm is a library of database functions that uses extensible hashing and work similar to the standard UNIX dbm. These routines are provided to a programmer needing to create and manipulate a hashed database."
+    description = ("gdbm is a library of database functions that uses "
+                   "extensible hashing and work similar to "
+                   "the standard UNIX dbm. "
+                   "These routines are provided to a programmer needing "
+                   "to create and manipulate a hashed database.")
     topics = ("conan", "gdbm", "dbm", "hash", "database")
     url = "https://github.com/bincrafters/conan-gdbm"
     homepage = "https://www.gnu.org.ua/software/gdbm/gdbm.html"
@@ -22,17 +24,26 @@ class GdbmConan(ConanFile):
         "fPIC": [True, False],
         "libiconv": [True, False],
         "readline": [True, False],
+        "libgdbm_compat": [True, False],
+        "gdbmtool_debug": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "libiconv": True,
         "readline": True,
+        "libgdbm_compat": True,
+        "gdbmtool_debug": True,
     }
-    _source_subfolder = "sources"
+
+    # Custom attributes for Bincrafters recipe conventions
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
 
     def config_options(self):
         del self.settings.compiler.libcxx
+        # TODO: probably has to remove fPIC if MSVC too (which currently won't
+        # work due to readline)
         if self.options.shared:
             del self.options.fPIC
 
@@ -51,47 +62,62 @@ class GdbmConan(ConanFile):
         filename = "{}-{}.tar.gz".format(self.name, self.version)
         url = "https://mirrors.tripadvisor.com/gnu/{}/{}".format(self.name, filename)
         sha256 = "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
-
-        dlfilepath = os.path.join(tempfile.gettempdir(), filename)
-        if os.path.exists(dlfilepath) and not get_env("GDBM_FORCE_DOWNLOAD", False):
-            self.output.info("Skipping download. Using cached {}".format(dlfilepath))
-        else:
-            self.output.info("Downloading {} from {}".format(self.name, url))
-            tools.download(url, dlfilepath)
-        tools.check_sha256(dlfilepath, sha256)
-        tools.untargz(dlfilepath)
+        tools.get(url, sha256=sha256)
 
         extracted_dir = "{}-{}".format(self.name, self.version)
         os.rename(extracted_dir, self._source_subfolder)
 
-        os.remove(os.path.join(self._source_subfolder, "src", "gram.c"))
+        if self.options.gdbmtool_debug:
+            self.output.warn("Removing files similar to calling "
+                             "`make -C src maintainer-clean-generic` "
+                             " for enable-gdbmtool-debug to take effect")
+            # Equivalent to `make -C src maintainer-clean-generic` needed
+            _del_files = ['gram.c', 'lex.c', 'gdbm.h', 'gram.h']
+            for _f in _del_files:
+                try:
+                    os.remove(os.path.join(self._source_subfolder, "src", _f))
+                except FileNotFoundError:
+                    pass
 
     def build(self):
         conf_args = [
+            "--disable-dependency-tracking",  # Speeds up one-time builds
             "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
-            "--enable-gdbmtool-debug",
-            "--disable-static" if self.options.shared else "--enable-static",
-            "--enable-shared" if self.options.shared else "--disable-shared",
-            "--disable-static" if self.options.shared else "--enable-static",
             "--with-libiconv-prefix" if self.options.libiconv else "--libiconv-prefix",
             "--with-libintl-prefix",  # if self.options.libintl else "--libintl-prefix",
             "--with-readline" if self.options.readline else "--without-readline",
         ]
-        if not self.options.shared:
-            conf_args.append("--with-pic" if self.options.fPIC else "--without-pic")
 
+        if self.options.shared:
+            conf_args.append("--disable-static")
+            conf_args.append("--enable-shared")
+            conf_args.append("--disable-rpaths")
+        else:
+            conf_args.append("--enable-static")
+            conf_args.append("--disable-shared")
+            conf_args.append("--with-pic" if self.options.fPIC
+                             else "--without-pic")
+
+        if self.options.libgdbm_compat:
+            conf_args.append("--enable-libgdbm-compat")
+
+        if self.options.gdbmtool_debug:
+            conf_args.append("--enable-gdbmtool-debug")
+
+        conf_dir = os.path.join(self.source_folder, self._source_subfolder)
         autotools = AutoToolsBuildEnvironment(self)
-        autotools.configure(configure_dir=os.path.join(self.source_folder, self._source_subfolder), args=conf_args)
-        autotools.make(args=["V=1", "-j1", ])
+        autotools.configure(configure_dir=conf_dir, args=conf_args)
+        autotools.make(args=["V=1"])
 
     def package(self):
         with tools.chdir(self.build_folder):
             autotools = AutoToolsBuildEnvironment(self)
             autotools.install()
         self.copy("COPYING",
-                  src=os.path.join(os.path.join(self.source_folder, self._source_subfolder)),
+                  src=os.path.join(os.path.join(self.source_folder,
+                                                self._source_subfolder)),
                   dst="licenses")
 
     def package_info(self):
         self.cpp_info.includedirs = ["include"]
-        self.cpp_info.libs = ["gdbm"]
+        self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
* Add a new option for `--enable-libgdbm-compat`: https://www.gnu.org.ua/software/gdbm/manual/html_node/Compatibility.html
* make `--enable-gdbmtool-debug` an option and not standard, and delete all files that would be deleted by the target recommended to be run (cf Notes). You already were deleting the `gram.c` file which was the problematic one, but might as well do all.
* If shared, pass `--disable-rpaths` (not sure if needed, and cf [Fedora gdbm.spec](https://src.fedoraproject.org/rpms/gdbm/blob/master/f/gdbm.spec#_73))
* Some other miscs changes


Notes:

If you add `--enable-gdbmtool-debug` it tells you this:
```
NOTE: You used the --enable-gdbmtool-debug option. In order for your changes
NOTE: to take effect, please run the following command prior to building the
NOTE: package:
NOTE:
NOTE:   make -C src maintainer-clean-generic
NOTE:
```

Here the output of running it
```
$ make -C src maintainer-clean-generic
This command is intended for maintainers to use
it deletes files that may require special tools to rebuild.
rm -f gram.c
rm -f lex.c
test -z "gdbm.h gram.h" || rm -f gdbm.h gram.h
```